### PR TITLE
Create notification procedure with dual-window system

### DIFF
--- a/rpi/src/notif/README.md
+++ b/rpi/src/notif/README.md
@@ -1,0 +1,274 @@
+# Polypod Notification System
+
+**Author:** Riley Anderson  
+**Date:** February 17, 2026
+
+## Overview
+
+This system enables notifications from local machine or external APIs to be displayed as Flutter widgets on the top screen of the Polypod device. The system consists ofPython backend for receiving and processing notifications and a Flutter frontend for displaying them with custom configurations.
+
+## Architecture
+
+```
+┌─────────────────┐
+│  Notification   │ (JSON format)
+│    Source       │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│   notify.py     │ ◄── Processes notification
+│                 │     Applies source-specific config
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ current_        │ ◄── JSON file bridge
+│ notification.   │
+│ json            │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Notification    │ ◄── Monitors file for changes
+│ Controller      │
+│ (Dart)          │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Notification    │ ◄── Displays on top screen
+│ Overlay Widget  │     with animations
+└─────────────────┘
+```
+
+## Components
+
+### Python Backend
+
+#### 1. `notify.py`
+Main notification handler that:
+- Validates incoming notification JSON
+- Retrieves source-specific configuration
+- Writes formatted notification to bridge file
+
+**Functions:**
+- `notify(notification_json)` - Main entry point for notifications
+- `get_config_for_source(source)` - Returns configuration for source
+- `send_to_flutter(payload)` - Writes to JSON bridge file
+
+#### 2. `common_configs.py`
+Configuration definitions for notification display:
+- `MEDIA_SIZES` - Predefined media dimensions (none, small, medium, large, full)
+- `TEXT_SIZES` - Font sizes (small, medium, large)
+- `DefaultConfig` - Base configuration
+- `NFLConfig` - Sports notifications (large media)
+- `NASAConfig` - Science notifications (smaller info text)
+
+#### 3. `base_notif.json`
+Template showing expected notification structure:
+```json
+{
+  "notifType": "base",
+  "fromSource": "",
+  "data": {
+    "timestamp": "",
+    "media": "",
+    "headline": "",
+    "info": "",
+    "seemore": ""
+  }
+}
+```
+
+### Flutter Frontend
+
+#### 1. `parse_to_widget.dart`
+Core notification parsing and widget implementation:
+- `NotificationConfig` - Configuration data model
+- `NotificationData` - Notification data model
+- `parseNotificationFromFile()` - Reads and parses JSON file
+- `NotificationWidget` - Displays notification with custom styling
+
+#### 2. `notification_controller.dart`
+State management for notifications:
+- Monitors `current_notification.json` for changes (500ms polling)
+- Manages notification lifecycle
+- Notifies listeners when new notification arrives
+- Provides methods for clearing/dismissing notifications
+
+#### 3. `notification_overlay.dart`
+Display widget with animations:
+- Slide-in animation from top
+- Fade in/out transitions
+- Auto-dismiss after 10 seconds
+- Manual dismiss button
+- "See More" button support
+
+#### 4. Integration in `main.dart` and `top_screen.dart`
+- `NotificationController` instantiated in main app state
+- Overlay positioned at top of screen stack
+- Receives updates automatically when Python writes new notification
+
+## Notification Format
+
+### Input (to `notify.py`)
+
+```json
+{
+  "notifType": "base",
+  "fromSource": "NFL|NASA|WeatherAPI|etc",
+  "data": {
+    "timestamp": "2026-02-17T10:30:00Z",
+    "media": "url_or_path_to_image",
+    "headline": "Main notification text",
+    "info": "Additional details",
+    "seemore": "url_for_qr_code"
+  }
+}
+```
+
+### Bridge File (written by Python, read by Dart)
+
+```json
+{
+  "notification": {
+    "timestamp": "2026-02-17T10:30:00Z",
+    "media": "",
+    "headline": "Chiefs Win Super Bowl!",
+    "info": "Kansas City Chiefs defeat the Eagles 31-28.",
+    "seemore": "https://example.com/nfl"
+  },
+  "config": {
+    "media_size": [256.0, 192.0],
+    "headline_size": 36.0,
+    "info_size": 24.0
+  },
+  "from_source": "NFL"
+}
+```
+
+## Usage
+
+### Sending a Notification (Python)
+
+```python
+from notify import notify
+
+notification = {
+    "notifType": "base",
+    "fromSource": "NFL",  # or "NASA", "", etc.
+    "data": {
+        "timestamp": "2026-02-17T10:30:00Z",
+        "media": "",
+        "headline": "Chiefs Win Super Bowl!",
+        "info": "Kansas City Chiefs defeat the Eagles 31-28.",
+        "seemore": "https://example.com/details"
+    }
+}
+
+notify(notification)
+```
+
+### Running Test Notifications
+
+```bash
+cd rpi/src/notif
+python test_notifications.py
+```
+
+This will send a series of test notifications demonstrating:
+- Default configuration
+- NFL configuration (large media)
+- NASA configuration (smaller text)
+- Custom API (default config)
+
+### Flutter App Display
+
+The notification will automatically appear on the top screen with:
+- Source label (e.g., "NFL" in cyan)
+- Media image (if provided, sized per config)
+- Headline (large bold text)
+- Info text (medium size)
+- Timestamp (small gray text)
+- "See More" button (if URL provided)
+- Close button (top-right corner)
+
+## Adding New Source Configurations
+
+To add a custom configuration for a new API:
+
+1. **Add to `COMMON_CONFIGS` list** in `common_configs.py`:
+   ```python
+   COMMON_CONFIGS = ['NFL', 'NASA', 'MyNewAPI']
+   ```
+
+2. **Create configuration class**:
+   ```python
+   class MyNewAPIConfig():
+       media_size = MEDIA_SIZES.full  # Choose size
+       headline_size = TEXT_SIZES.large
+       info_size = TEXT_SIZES.small
+   ```
+
+3. **Update `get_config_for_source()`** in `notify.py`:
+   ```python
+   elif source == 'MyNewAPI':
+       from common_configs import MyNewAPIConfig
+       return MyNewAPIConfig()
+   ```
+
+## File Structure
+
+```
+rpi/src/
+├── notif/
+│   ├── notify.py                    # Main Python handler
+│   ├── common_configs.py            # Configuration definitions
+│   ├── base_notif.json              # Template
+│   ├── parse_to_widget.dart         # Dart parsing & widget
+│   ├── current_notification.json    # Bridge file (generated)
+│   └── test_notifications.py        # Testing script
+│
+└── polypod_hw/lib/
+    ├── main.dart                    # App entry (integrates controller)
+    ├── controllers/
+    │   └── notification_controller.dart  # State management
+    ├── widgets/
+    │   └── notification_overlay.dart     # Display widget
+    └── screens/
+        └── top_screen.dart          # Integration point
+```
+
+## Troubleshooting
+
+### Notifications not appearing:
+1. Check that `current_notification.json` is being created in `rpi/src/notif/`
+2. Verify Flutter app has read permissions for the file
+3. Check Flutter console for parsing errors
+4. Ensure notification controller is properly initialized in main.dart
+
+### Configuration not applied:
+1. Verify source name exactly matches entry in `COMMON_CONFIGS`
+2. Check that config class is imported in `get_config_for_source()`
+3. Confirm config values are properly formatted (tuples for sizes)
+
+### File path issues:
+- Update `notificationFilePath` in `NotificationController` if running from different directory
+- Use absolute paths for testing
+
+## Testing
+
+1. Start the Flutter app:
+   ```bash
+   cd rpi/src/polypod_hw
+   flutter run
+   ```
+
+2. Run test notifications:
+   ```bash
+   cd rpi/src/notif
+   python test_notifications.py
+   ```
+
+3. Observe notifications appearing on the top screen with different configurations

--- a/rpi/src/notif/base_notif.json
+++ b/rpi/src/notif/base_notif.json
@@ -1,0 +1,12 @@
+
+{
+    "notifType": "base",
+    "fromSource": "",
+    "data" : {
+        "timestamp": "",
+        "media": "",
+        "headline": "",
+        "info": "",
+        "seemore": ""
+    }
+}

--- a/rpi/src/notif/common_configs.py
+++ b/rpi/src/notif/common_configs.py
@@ -1,0 +1,41 @@
+'''
+RILEY ANDERSON
+02/17/2026
+'''
+
+# this file lists common API's custom configurations, and which APIs have such configurations
+
+COMMON_CONFIGS = ['NFL', 'NASA']
+
+#classes for spec options
+
+class MEDIA_SIZES():
+    # desired max media size in pixels
+    # x, y
+    none = (0, 0)
+    small = (64.0, 48.0)
+    medium = (128.0, 96.0)
+    large = (256.0, 192.0)
+    full = (640.0, 480.0)
+
+class TEXT_SIZES():
+    small = 12.0
+    medium = 24.0
+    large = 36.0
+
+class DefaultConfig():
+    media_size = MEDIA_SIZES.medium
+    headline_size = TEXT_SIZES.large
+    info_size = TEXT_SIZES.medium
+
+# NFL-specific configuration - small media for team logos on score
+class NFLConfig():
+    media_size = MEDIA_SIZES.medium
+    headline_size = TEXT_SIZES.large
+    info_size = TEXT_SIZES.medium
+
+# NASA-specific configuration - assumes pic of the day
+class NASAConfig():
+    media_size = MEDIA_SIZES.full  # Space image fills
+    headline_size = TEXT_SIZES.large
+    info_size = TEXT_SIZES.small  # more detailed scientific info in smaller text

--- a/rpi/src/notif/current_notification.json
+++ b/rpi/src/notif/current_notification.json
@@ -1,0 +1,18 @@
+{
+  "notification": {
+    "timestamp": "2026-02-17T10:30:00Z",
+    "media": "",
+    "headline": "Severe Weather Warning",
+    "info": "Heavy snowfall expected tonight. Road conditions may be hazardous.",
+    "seemore": ""
+  },
+  "config": {
+    "media_size": [
+      128.0,
+      96.0
+    ],
+    "headline_size": 36.0,
+    "info_size": 24.0
+  },
+  "from_source": "WeatherAPI"
+}

--- a/rpi/src/notif/notify.py
+++ b/rpi/src/notif/notify.py
@@ -1,0 +1,126 @@
+'''
+RILEY ANDERSON
+02/17/2026
+'''
+
+# this file contains the function call that will send a notification to the flutter interface to be displayed
+
+import json
+from common_configs import COMMON_CONFIGS
+
+# initially, we shall assume that all notifications will come in the 'base' format, containing the following data:
+'''        
+        {   
+            we read notiftype to ensure that this is a base notification
+            "notifType": "base",
+            we read to see if there are any special configurations for this specific API
+            "fromSource" : ""
+            an internal data dictionary holds all info
+            "data" : {
+            timestamp
+                "timestamp": "2024-01-15T10:30:00Z",
+            a link to any images or media to be displayed
+                "media": "",
+            the text that will be displayed the largest
+                "headline": "",
+            smaller text below
+                "info": "",
+            if this is populated, a button will be displayed the the user that will prompt them if they want to see more.
+            if the button is pressed, a qr code will be generated and displayed on the top screen for them to scan to see more about the notif.
+                "seemore": ""
+            }
+        }
+        
+'''
+
+# parse any special data and then pass off cleaned notif to widget builder with the proper parameters. 
+def notify(notification_json):
+    """
+    Main notification handler that processes incoming notifications.
+    Args:
+        notification_json: Either a JSON string or a dictionary containing notification data
+    Returns:
+        bool: True if notification was processed successfully, False otherwise
+    """
+    try:
+        # Parse the notification if it's a string
+        if isinstance(notification_json, str):
+            data = json.loads(notification_json)
+        elif isinstance(notification_json, dict):
+            data = notification_json
+        else:
+            print(f"Invalid notification type: {type(notification_json)}")
+            return False
+        
+        # Validate notification structure
+        if not isinstance(data, dict):
+            print("Notification is not a dictionary")
+            return False
+            
+        if data.get('notifType') != 'base':
+            print(f"Unsupported notification type: {data.get('notifType')}")
+            return False
+        
+        # Get the source and apply appropriate config
+        from_source = data.get('fromSource', '')
+        config = get_config_for_source(from_source)
+        
+        # Prepare the notification payload with config
+        notification_payload = {
+            'notification': data.get('data', {}),
+            'config': {
+                'media_size': config.media_size,
+                'headline_size': config.headline_size,
+                'info_size': config.info_size,
+            },
+            'from_source': from_source
+        }
+        
+        # Write to file for Flutter to read
+        send_to_flutter(notification_payload)
+        return True
+        
+    except json.JSONDecodeError as e:
+        print(f"JSON decode error: {e}")
+        return False
+    except Exception as e:
+        print(f"Error processing notification: {e}")
+        return False
+
+
+def get_config_for_source(source):
+    """
+    Get the configuration for a specific notification source.
+    Args:
+        source: String identifier of the notification source
+    Returns:
+        Configuration object (either custom or default)
+    """
+    if source in COMMON_CONFIGS:
+        if source == 'NFL':
+            from common_configs import NFLConfig
+            return NFLConfig()
+        elif source == 'NASA':
+            from common_configs import NASAConfig
+            return NASAConfig()
+    
+    # Return default config if no custom config exists
+    from common_configs import DefaultConfig
+    return DefaultConfig()
+
+
+def send_to_flutter(payload):
+    """
+    Write notification data to a JSON file that Flutter will monitor.
+    Args:
+        payload: Dictionary containing notification data and config
+    """
+    import os
+    
+    # Write to a file in the notif directory
+    output_path = os.path.join(os.path.dirname(__file__), 'current_notification.json')
+    
+    with open(output_path, 'w') as f:
+        json.dump(payload, f, indent=2)
+    
+    print(f"Notification sent to Flutter: {payload['from_source']}")

--- a/rpi/src/notif/test_notifications.py
+++ b/rpi/src/notif/test_notifications.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+'''
+RILEY ANDERSON
+02/17/2026
+Test script to send notifications to the Flutter interface
+'''
+
+import json
+import sys
+import os
+
+# Add the notif directory to the path
+sys.path.insert(0, os.path.dirname(__file__))
+
+from notify import notify
+
+def send_test_notification(source='', headline='Test Notification', 
+                          info='This is a test notification', 
+                          media='', seemore=''):
+    """
+    Send a test notification to the Flutter app
+    """
+    notification = {
+        "notifType": "base",
+        "fromSource": source,
+        "data": {
+            "timestamp": "2026-02-17T10:30:00Z",
+            "media": media,
+            "headline": headline,
+            "info": info,
+            "seemore": seemore
+        }
+    }
+    
+    print(f"Sending notification from: {source or 'Local Machine'}")
+    print(f"Headline: {headline}")
+    
+    success = notify(notification)
+    
+    if success:
+        print("✓ Notification sent successfully!")
+    else:
+        print("✗ Failed to send notification")
+    
+    return success
+
+
+def main():
+    """Run various test notifications"""
+    print("=" * 60)
+    print("NOTIFICATION SYSTEM TEST")
+    print("=" * 60)
+    print()
+    
+    # Test 1: Default notification (no specific source)
+    print("Test 1: Default Notification")
+    print("-" * 60)
+    send_test_notification(
+        source='',
+        headline='System Ready',
+        info='All systems operational. Ready to receive notifications.',
+    )
+    print()
+    
+    import time
+    time.sleep(15)
+    
+    # Test 2: NFL notification (custom config - large media)
+    print("Test 2: NFL Notification")
+    print("-" * 60)
+    send_test_notification(
+        source='NFL',
+        media='https://a.espncdn.com/i/teamlogos/nfl/500/kc.png',
+        headline='Chiefs Win Super Bowl!',
+        info='Kansas City Chiefs defeat the Eagles 31-28 in overtime.',
+        seemore='https://example.com/nfl/superbowl'
+    )
+    print()
+    
+    time.sleep(15)
+    
+    # Test 3: NASA notification (custom config - smaller text)
+    print("Test 3: NASA Notification")
+    print("-" * 60)
+    send_test_notification(
+        source='NASA',
+        media='https://www.nasa.gov/wp-content/uploads/2026/02/nycicy-oli-20260128-lrg.jpg',
+        headline='New Exoplanet Discovered',
+        info='Astronomers have discovered a potentially habitable exoplanet 100 light-years away.',
+        seemore='https://example.com/nasa/exoplanet'
+    )
+    print()
+    
+    time.sleep(15)
+    
+    # Test 4: Custom API notification (uses default config)
+    print("Test 4: Weather Alert")
+    print("-" * 60)
+    send_test_notification(
+        source='WeatherAPI',
+        headline='Severe Weather Warning',
+        info='Heavy snowfall expected tonight. Road conditions may be hazardous.',
+    )
+    print()
+    
+    print("=" * 60)
+    print("All tests completed!")
+    print("Check the Flutter app top screen for notifications.")
+    print("=" * 60)
+
+
+if __name__ == '__main__':
+    main()

--- a/rpi/src/polypod_hw/lib/controllers/notification_controller.dart
+++ b/rpi/src/polypod_hw/lib/controllers/notification_controller.dart
@@ -1,0 +1,118 @@
+// RILEY ANDERSON
+// 02/17/2026
+// Controller for managing notification state and file monitoring
+
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+
+import '../models/notification_models.dart';
+
+/// Controller that monitors notification file and manages notification state
+class NotificationController extends ChangeNotifier {
+  NotificationData? _currentNotification;
+  Timer? _fileWatchTimer;
+  String? _lastFileContent;
+  final String notificationFilePath;
+
+  NotificationController({
+    String? notificationPath,
+  }) : notificationFilePath = notificationPath ??
+            '../notif/current_notification.json' {
+    _startWatching();
+  }
+
+  NotificationData? get currentNotification => _currentNotification;
+
+  bool get hasNotification => _currentNotification != null;
+
+  /// Start watching the notification file for changes
+  void _startWatching() {
+    // Check file every 500ms for changes
+    _fileWatchTimer = Timer.periodic(
+      const Duration(milliseconds: 500),
+      (_) => _checkForUpdates(),
+    );
+  }
+
+  /// Check if the notification file has been updated
+  Future<void> _checkForUpdates() async {
+    try {
+      // Resolve the full path
+      final file = File(_resolveFilePath());
+
+      if (!await file.exists()) {
+        return;
+      }
+
+      final contents = await file.readAsString();
+
+      // Only parse if content has changed
+      if (contents != _lastFileContent) {
+        _lastFileContent = contents;
+        final notification = await parseNotificationFromFile(_resolveFilePath());
+
+        if (notification != null) {
+          _currentNotification = notification;
+          notifyListeners();
+        }
+      }
+    } catch (e) {
+      if (kDebugMode) {
+        print('Error checking for notification updates: $e');
+      }
+    }
+  }
+
+  /// Resolve the notification file path relative to the app
+  String _resolveFilePath() {
+    // If absolute path, use as-is
+    if (notificationFilePath.startsWith('/') ||
+        notificationFilePath.contains(':\\')) {
+      return notificationFilePath;
+    }
+
+    // Resolve relative to the Flutter app directory
+    // From polypod_hw, go up one level to src, then into notif
+    final currentDir = Directory.current.path;
+    // if (kDebugMode) {
+    //   print('Looking for notification file at: $currentDir');
+    // }
+    
+    // Construct path: ../notif/current_notification.json from polypod_hw directory
+    final notifPath = '$currentDir${Platform.pathSeparator}..${Platform.pathSeparator}notif${Platform.pathSeparator}current_notification.json';
+    final normalizedPath = File(notifPath).absolute.path;
+    
+    // if (kDebugMode) {
+    //   print('Resolved notification path: $normalizedPath');
+    // }
+    
+    return normalizedPath;
+  }
+
+  /// Manually refresh notification
+  Future<void> refresh() async {
+    await _checkForUpdates();
+  }
+
+  /// Clear current notification
+  void clearNotification() {
+    _currentNotification = null;
+    notifyListeners();
+  }
+
+  /// Dismiss notification with auto-clear after duration
+  void dismissNotification({Duration? after}) {
+    if (after != null) {
+      Future.delayed(after, clearNotification);
+    } else {
+      clearNotification();
+    }
+  }
+
+  @override
+  void dispose() {
+    _fileWatchTimer?.cancel();
+    super.dispose();
+  }
+}

--- a/rpi/src/polypod_hw/lib/main.dart
+++ b/rpi/src/polypod_hw/lib/main.dart
@@ -15,6 +15,7 @@ import 'apps/settings_app.dart';
 import 'apps/notes_app.dart';
 import 'controllers/clock_timer_controller.dart';
 import 'controllers/idle_state_controller.dart';
+import 'controllers/notification_controller.dart';
 
 import 'multi_window/multi_window.dart';
 
@@ -139,6 +140,7 @@ class TopOnlyWindow extends StatefulWidget {
 class _TopOnlyWindowState extends State<TopOnlyWindow> {
   late IdleStateController _idleController;
   late ClockTimerController _timerController;
+  late NotificationController _notificationController;
   BaseApp _currentApp = const IdleApp();
   String _currentAppKey = 'Home';
 
@@ -154,6 +156,7 @@ class _TopOnlyWindowState extends State<TopOnlyWindow> {
     _idleController = IdleStateController();
     _idleController.setIdleCallback(_returnToIdle);
     _timerController = ClockTimerController();
+    _notificationController = NotificationController();
     _apps = {
       'Home': const HomeApp(),
       'Timer': ClockApp(controller: _timerController),
@@ -247,6 +250,7 @@ class _TopOnlyWindowState extends State<TopOnlyWindow> {
   void dispose() {
     _idleController.dispose();
     _timerController.dispose();
+    _notificationController.dispose();
     super.dispose();
   }
 
@@ -284,6 +288,7 @@ class _TopOnlyWindowState extends State<TopOnlyWindow> {
         child: TopScreen(
           currentApp: _currentApp,
           timerController: _timerController,
+          notificationController: _notificationController,
         ),
       ),
     );
@@ -437,6 +442,7 @@ class DualScreenHome extends StatefulWidget {
 class _DualScreenHomeState extends State<DualScreenHome> {
   late IdleStateController _idleController;
   late ClockTimerController _timerController;
+  late NotificationController _notificationController;
   BaseApp _currentApp = const IdleApp();
 
   late final Map<String, BaseApp> _apps;
@@ -447,6 +453,7 @@ class _DualScreenHomeState extends State<DualScreenHome> {
     _idleController = IdleStateController();
     _idleController.setIdleCallback(_returnToIdle);
     _timerController = ClockTimerController();
+    _notificationController = NotificationController();
     _apps = {
       'Home': const HomeApp(),
       'Timer': ClockApp(controller: _timerController),
@@ -461,6 +468,7 @@ class _DualScreenHomeState extends State<DualScreenHome> {
   void dispose() {
     _idleController.dispose();
     _timerController.dispose();
+    _notificationController.dispose();
     super.dispose();
   }
 
@@ -497,6 +505,7 @@ class _DualScreenHomeState extends State<DualScreenHome> {
               TopScreen(
                 currentApp: _currentApp,
                 timerController: _timerController,
+                notificationController: _notificationController,
               ),
               // Bottom Screen (480x320)
               BottomScreen(

--- a/rpi/src/polypod_hw/lib/models/notification_models.dart
+++ b/rpi/src/polypod_hw/lib/models/notification_models.dart
@@ -1,0 +1,227 @@
+// RILEY ANDERSON
+// 02/17/2026
+// this file contains the functions for how each api and local notification shall be displayed
+// also has a function for interpreting new configs sent by polywork api
+
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/material.dart';
+import '../config/theme_config.dart';
+import '../config/screen_config.dart';
+
+/// Configuration for notification display
+class NotificationConfig {
+  final Size mediaSize;
+  final double headlineSize;
+  final double infoSize;
+
+  NotificationConfig({
+    required this.mediaSize,
+    required this.headlineSize,
+    required this.infoSize,
+  });
+
+  factory NotificationConfig.fromJson(Map<String, dynamic> json) {
+    final mediaSizeList = json['media_size'] as List;
+    return NotificationConfig(
+      mediaSize: Size(
+        (mediaSizeList[0] as num).toDouble(),
+        (mediaSizeList[1] as num).toDouble(),
+      ),
+      headlineSize: (json['headline_size'] as num).toDouble(),
+      infoSize: (json['info_size'] as num).toDouble(),
+    );
+  }
+}
+
+/// Notification data model
+class NotificationData {
+  final String timestamp;
+  final String media;
+  final String headline;
+  final String info;
+  final String seemore;
+  final String fromSource;
+  final NotificationConfig config;
+
+  NotificationData({
+    required this.timestamp,
+    required this.media,
+    required this.headline,
+    required this.info,
+    required this.seemore,
+    required this.fromSource,
+    required this.config,
+  });
+
+  factory NotificationData.fromJson(Map<String, dynamic> json) {
+    final notificationData = json['notification'] as Map<String, dynamic>;
+    final configData = json['config'] as Map<String, dynamic>;
+
+    return NotificationData(
+      timestamp: notificationData['timestamp'] ?? '',
+      media: notificationData['media'] ?? '',
+      headline: notificationData['headline'] ?? '',
+      info: notificationData['info'] ?? '',
+      seemore: notificationData['seemore'] ?? '',
+      fromSource: json['from_source'] ?? '',
+      config: NotificationConfig.fromJson(configData),
+    );
+  }
+}
+
+/// Parse notification from JSON file
+Future<NotificationData?> parseNotificationFromFile(String filePath) async {
+  try {
+    final file = File(filePath);
+    if (!await file.exists()) {
+      return null;
+    }
+
+    final contents = await file.readAsString();
+    final json = jsonDecode(contents) as Map<String, dynamic>;
+    
+    return NotificationData.fromJson(json);
+  } catch (e) {
+    print('Error parsing notification: $e');
+    return null;
+  }
+}
+
+/// Widget that displays a notification with custom configuration
+class NotificationWidget extends StatelessWidget {
+  final NotificationData notification;
+  final VoidCallback? onSeeMore;
+
+  const NotificationWidget({
+    Key? key,
+    required this.notification,
+    this.onSeeMore,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: ScreenConfig.topScreenWidth,
+      height: ScreenConfig.topScreenHeight,
+      padding: const EdgeInsets.all(24.0),
+      decoration: BoxDecoration(
+        color: EarthyTheme.forestGreen,
+        border: Border.all(color: EarthyTheme.wheat, width: 3),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          // Source label
+          if (notification.fromSource.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12.0),
+              child: Text(
+                notification.fromSource.toUpperCase(),
+                style: TextStyle(
+                  color: EarthyTheme.wheat,
+                  fontSize: 14,
+                  fontWeight: FontWeight.bold,
+                  letterSpacing: 2.0,
+                ),
+              ),
+            ),
+          
+          // Media (if present)
+          if (notification.media.isNotEmpty &&
+              notification.config.mediaSize.width > 0)
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.only(bottom: 12.0),
+                child: Container(
+                  width: notification.config.mediaSize.width,
+                  height: notification.config.mediaSize.height,
+                  decoration: BoxDecoration(
+                    color: EarthyTheme.surface,
+                    borderRadius: BorderRadius.circular(8.0),
+                    border: Border.all(color: EarthyTheme.bark, width: 2),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(8.0),
+                    child: _buildMediaWidget(),
+                  ),
+                ),
+              ),
+            ),
+
+          // Headline
+          if (notification.headline.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12.0),
+              child: Text(
+                notification.headline,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: EarthyTheme.textPrimary,
+                  fontSize: notification.config.headlineSize,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+
+          // Info
+          if (notification.info.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12.0),
+              child: Text(
+                notification.info,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: EarthyTheme.textSecondary,
+                  fontSize: notification.config.infoSize,
+                ),
+              ),
+            ),
+
+          // See More button
+          if (notification.seemore.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8.0),
+              child: ElevatedButton(
+                onPressed: onSeeMore,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: EarthyTheme.terracotta,
+                  foregroundColor: EarthyTheme.textPrimary,
+                  padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
+                ),
+                child: const Text('See More', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMediaWidget() {
+    // Check if media is a URL or local path
+    if (notification.media.startsWith('http://') ||
+        notification.media.startsWith('https://')) {
+      return Image.network(
+        notification.media,
+        fit: BoxFit.cover,
+        errorBuilder: (context, error, stackTrace) {
+          return const Center(
+            child: Icon(Icons.error, color: Colors.red),
+          );
+        },
+      );
+    } else if (notification.media.isNotEmpty) {
+      return Image.file(
+        File(notification.media),
+        fit: BoxFit.cover,
+        errorBuilder: (context, error, stackTrace) {
+          return const Center(
+            child: Icon(Icons.error, color: Colors.red),
+          );
+        },
+      );
+    }
+    return Container();
+  }
+}

--- a/rpi/src/polypod_hw/lib/screens/top_screen.dart
+++ b/rpi/src/polypod_hw/lib/screens/top_screen.dart
@@ -3,16 +3,20 @@ import 'package:polypod_hw/config/theme_config.dart';
 import '../config/screen_config.dart';
 import '../apps/base_app.dart';
 import '../controllers/clock_timer_controller.dart';
+import '../controllers/notification_controller.dart';
+import '../widgets/notification_overlay.dart';
 
 /// top screen widget that will display the mouth animations, notifications, and addtl info from bottom
 class TopScreen extends StatelessWidget {
   final BaseApp currentApp;
   final ClockTimerController timerController;
+  final NotificationController notificationController;
 
   const TopScreen({
     Key? key,
     required this.currentApp,
     required this.timerController,
+    required this.notificationController,
   }) : super(key: key);
 
   @override
@@ -24,6 +28,13 @@ class TopScreen extends StatelessWidget {
       child: Stack(
         children: [
           currentApp,
+          // Notification overlay fills entire screen, centered
+          Positioned.fill(
+            child: NotificationOverlay(
+              controller: notificationController,
+            ),
+          ),
+          // Bottom overlay bar
           Positioned(
             left: 0,
             right: 0,
@@ -91,6 +102,7 @@ class TimerOverlayItem extends StatelessWidget {
     return AnimatedBuilder(
       animation: controller,
       builder: (context, child) {
+        final status = controller.isRunning ? 'Running' : 'Ready';
         return Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
           decoration: BoxDecoration(

--- a/rpi/src/polypod_hw/lib/widgets/notification_overlay.dart
+++ b/rpi/src/polypod_hw/lib/widgets/notification_overlay.dart
@@ -1,0 +1,132 @@
+// RILEY ANDERSON
+// 02/17/2026
+// Notification display widget for top screen overlay
+
+import 'package:flutter/material.dart';
+import '../controllers/notification_controller.dart';
+import '../models/notification_models.dart';
+import '../config/theme_config.dart';
+
+/// Overlay widget that displays notifications on the top screen
+class NotificationOverlay extends StatefulWidget {
+  final NotificationController controller;
+
+  const NotificationOverlay({
+    Key? key,
+    required this.controller,
+  }) : super(key: key);
+
+  @override
+  State<NotificationOverlay> createState() => _NotificationOverlayState();
+}
+
+class _NotificationOverlayState extends State<NotificationOverlay>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _animationController;
+  late Animation<double> _scaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    
+    // Setup scale animation from center
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 1000),
+      vsync: this,
+    );
+
+    _scaleAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.bounceInOut,
+    ));
+
+    // Listen to notification changes
+    widget.controller.addListener(_onNotificationChanged);
+    
+    // Animate in if we already have a notification
+    if (widget.controller.hasNotification) {
+      _animationController.forward();
+    }
+  }
+
+  void _onNotificationChanged() {
+    if (widget.controller.hasNotification) {
+      _animationController.forward();
+      // Auto-dismiss after 10 seconds
+      Future.delayed(const Duration(seconds: 10), () {
+        if (mounted) {
+          _animationController.reverse().then((_) {
+            widget.controller.clearNotification();
+          });
+        }
+      });
+    } else {
+      _animationController.reverse();
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onNotificationChanged);
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  void _handleSeeMore() {
+    // TODO: Implement QR code generation and display
+    // For now, just keep the notification visible longer
+    print('See more tapped for: ${widget.controller.currentNotification?.headline}');
+  }
+
+  void _handleDismiss() {
+    _animationController.reverse().then((_) {
+      widget.controller.clearNotification();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: widget.controller,
+      builder: (context, child) {
+        if (!widget.controller.hasNotification) {
+          return const SizedBox.shrink();
+        }
+
+        return Center(
+          child: ScaleTransition(
+            scale: _scaleAnimation,
+            child: Stack(
+              children: [
+                NotificationWidget(
+                  notification: widget.controller.currentNotification!,
+                  onSeeMore: _handleSeeMore,
+                ),
+                // Close button
+                Positioned(
+                  top: 12,
+                  right: 12,
+                  child: IconButton(
+                    icon: Icon(
+                      Icons.close_rounded,
+                      color: EarthyTheme.wheat,
+                      size: 28,
+                    ),
+                    onPressed: _handleDismiss,
+                    style: IconButton.styleFrom(
+                      backgroundColor: EarthyTheme.bark,
+                      padding: const EdgeInsets.all(8),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
Issue: 27, 5

Add notification capability and integrate it to overlay top screen.

Has a completely modular system that allows a singular python call to be parsed into a notification and displayed via flutter. This allows a singular json string to be passed from device (env sensors) or via an api call without modification. Notification sources can have custom configurations defined in common_configs.py (the idea being that common notification types would benefit from custom notification view).

Readme is pretty extensive, and python test (test_notifications.py) shows a variety of different anticipated notification types.

(close notif button will be moved/removed later, but for testing purposes I've left it where it is)